### PR TITLE
feat: make w3c base and dark styles optional

### DIFF
--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -134,6 +134,8 @@ interface Conf {
   noToc: boolean;
   /** Disables injecting ReSpec styles */
   noReSpecCSS?: boolean;
+  /** Disables auto loading of W3C base and dark styles */
+  noBaseCSS?: boolean;
 
   /** Indicates whether the document is a preview */
   isPreview?: boolean;

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -28,7 +28,7 @@ function attachFixupScript() {
 
 // Creates a collection of resource hints to improve the loading performance
 // of the W3C resources.
-function createResourceHints() {
+function createResourceHints(conf) {
   /** @type {ResourceHintOption[]}  */
   const opts = [
     {
@@ -40,52 +40,33 @@ function createResourceHints() {
       href: "https://www.w3.org/scripts/TR/2021/fixup.js",
       as: "script",
     },
-    {
-      hint: "preload", // all specs include on base.css.
-      href: getStyleUrl("base.css").href,
-      as: "style",
-    },
-    {
-      hint: "preload",
-      href: getStyleUrl("dark.css").href,
-      as: "style",
-    },
-    {
-      hint: "preload", // all specs show the logo.
-      href: "https://www.w3.org/StyleSheets/TR/2021/logos/W3C",
-      as: "image",
-      corsMode: "anonymous",
-    },
   ];
+  if (!conf.noBaseCSS) {
+    opts.push(
+      {
+        hint: "preload", // all specs include on base.css.
+        href: getStyleUrl("base.css").href,
+        as: "style",
+      },
+      {
+        hint: "preload",
+        href: getStyleUrl("dark.css").href,
+        as: "style",
+      }
+    );
+  }
+  opts.push({
+    hint: "preload", // all specs show the logo.
+    href: "https://www.w3.org/StyleSheets/TR/2021/logos/W3C",
+    as: "image",
+    corsMode: "anonymous",
+  });
   const resourceHints = document.createDocumentFragment();
   for (const link of opts.map(createResourceHint)) {
     resourceHints.appendChild(link);
   }
   return resourceHints;
 }
-
-// Collect elements for insertion (document fragment)
-const elements = createResourceHints();
-
-// Opportunistically apply base style
-elements.appendChild(
-  html`<link
-    rel="stylesheet"
-    href="https://www.w3.org/StyleSheets/TR/2021/base.css"
-    class="removeOnSave"
-  />`
-);
-if (!document.head.querySelector("meta[name=viewport]")) {
-  // Make meta viewport the first element in the head.
-  elements.prepend(
-    html`<meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />`
-  );
-}
-
-document.head.prepend(elements);
 
 /**
  * @param {URL|string} linkURL
@@ -102,17 +83,43 @@ function styleMover(linkURL) {
  * @param {Conf} conf
  */
 export function run(conf) {
+  const elements = createResourceHints(conf);
+
+  if (!conf.noBaseCSS) {
+    elements.appendChild(
+      html`<link
+        rel="stylesheet"
+        href="https://www.w3.org/StyleSheets/TR/2021/base.css"
+        class="removeOnSave"
+      />`
+    );
+  }
+  if (!document.head.querySelector("meta[name=viewport]")) {
+    // Make meta viewport the first element in the head.
+    elements.prepend(
+      html`<meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, shrink-to-fit=no"
+      />`
+    );
+  }
+
+  document.head.prepend(elements);
+
   // Attach W3C fixup script after we are done.
   if (!conf.noToc) {
     sub("end-all", attachFixupScript, { once: true });
   }
 
-  const finalStyleURL = getStyleUrl(getStyleFile(conf));
-  document.head.appendChild(
-    html`<link rel="stylesheet" href="${finalStyleURL.href}" />`
-  );
-  // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
-  sub("beforesave", styleMover(finalStyleURL));
+  const styleFile = getStyleFile(conf);
+  const finalStyleURL = getStyleUrl(styleFile);
+  if (!(conf.noBaseCSS && styleFile === "base.css")) {
+    document.head.appendChild(
+      html`<link rel="stylesheet" href="${finalStyleURL.href}" />`
+    );
+    // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
+    sub("beforesave", styleMover(finalStyleURL));
+  }
 
   // Add color scheme meta tag and style
   /** @type HTMLMetaElement */
@@ -122,7 +129,7 @@ export function run(conf) {
     colorScheme = html`<meta name="color-scheme" content="light" />`;
     document.head.appendChild(colorScheme);
   }
-  if (colorScheme.content.includes("dark")) {
+  if (!conf.noBaseCSS && colorScheme.content.includes("dark")) {
     const darkModeStyleUrl = getStyleUrl("dark.css");
     document.head.appendChild(
       html`<link

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -250,6 +250,24 @@ describe("W3C - Style", () => {
     expect(linkBase.nextElementSibling).toBe(linkDarkMode);
   });
 
+  it("doesn't load base.css when noBaseCSS is set", async () => {
+    const ops = makeStandardOps({ noBaseCSS: true });
+    const doc = await makeRSDoc(ops);
+    const link = doc.querySelector(
+      `link[href="https://www.w3.org/StyleSheets/TR/2021/base.css"]`
+    );
+    expect(link).toBeNull();
+  });
+
+  it("doesn't load dark.css when noBaseCSS is set", async () => {
+    const ops = makeStandardOps({ noBaseCSS: true });
+    const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
+    const link = doc.querySelector(
+      `link[href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
+    );
+    expect(link).toBeNull();
+  });
+
   it("shouldn't include fixup.js when noToc is set", async () => {
     const ops = makeStandardOps();
     const newProps = {


### PR DESCRIPTION
## Summary
- add `noBaseCSS` flag to opt out of automatic W3C base and dark styles
- cover `noBaseCSS` in TypeScript config and tests

## Testing
- `pnpm lint`
- `pnpm test:build`
- `pnpm test -- --grep noBaseCSS` *(fails: Karma tests hang after START)*

------
https://chatgpt.com/codex/tasks/task_e_689b2e3c3e18832faf92077c5cc3a81b